### PR TITLE
fix compile error due to "-Werror=format-security"

### DIFF
--- a/supreme/lib/klt/writeFeatures.c
+++ b/supreme/lib/klt/writeFeatures.c
@@ -229,7 +229,7 @@ static void _printHeader(
   if (fp != stderr)  {
     fprintf(fp, "Feel free to place comments here.\n\n\n");
     fprintf(fp, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
-    fprintf(fp, warning_line);
+    fprintf(fp, "%s", warning_line);
     fprintf(fp, "\n");
   }
   fprintf(fp, "------------------------------\n");


### PR DESCRIPTION
On my Ubuntu 18.04 machine, with a default Python install, I can't compile the dependencies because setup.py insists on adding `-Werror=format-security` to CFLAGS and then chokes on one `fprintf()` call (see below). Trivial patch in PR.

```
supreme/lib/klt/writeFeatures.c: In function ‘_printHeader’:
supreme/lib/klt/writeFeatures.c:232:17: error: format not a string literal and no format arguments [-Werror=format-security]
     fprintf(fp, warning_line);
                 ^~~~~~~~~~~~
```