### PR TITLE
add some tweaks for more recent numpy

### DIFF
--- a/supreme/register/stack.py
+++ b/supreme/register/stack.py
@@ -196,8 +196,8 @@ def with_transform(images, matrices, weights=None, order=1,
 
             imsave('stack_%d.tiff' % n, tmp)
 
-    out = np.zeros(oshape, dtype=sc.ftype)
-    total_weights = np.zeros(oshape, dtype=float)
+    out = np.zeros(oshape.astype(int), dtype=sc.ftype)
+    total_weights = np.zeros(oshape.astype(int), dtype=float)
     for (s, bounds), w in zip(zip(sources, boundaries), weights):
         mask = mask_roi(s.shape[0], s.shape[1], bounds)
         out[mask] += (w * s)[mask]

--- a/supreme/resolve/iterative.py
+++ b/supreme/resolve/iterative.py
@@ -207,7 +207,7 @@ def solve(images, tf_matrices, scale, x0=None,
     else:
         raise ValueError('Invalid method (%s) specified.' % method)
 
-    return x.reshape(oshape)
+    return x.reshape(oshape.astype(int))
 
 def initial_guess_avg(images, tf_matrices, scale, oshape):
     """From the given low-resolution images and transforms, make an

--- a/supreme/transform/transform.py
+++ b/supreme/transform/transform.py
@@ -126,7 +126,7 @@ def _homography_coords(image, matrix, output_shape):
     image = np.atleast_3d(image)
     bands = image.shape[2]
 
-    coords = np.empty(np.r_[3,output_shape], dtype=SC.ftype)
+    coords = np.empty(np.r_[3,output_shape.astype(int)], dtype=SC.ftype)
     tf_coords = supreme.geometry.Grid(*output_shape[:2]).coords
     tf_coords = np.dot(tf_coords, np.linalg.inv(matrix).transpose())
     tf_coords[np.absolute(tf_coords) < SC.eps] = 0.


### PR DESCRIPTION
One more: on my default install, numpy 1.13.3 requires me to explicitly cast to int in some locations. Not sure if this is globally required, though.